### PR TITLE
Update Github Pages Workflow due to deprecation of set-env command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
           npm run export
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@3.5.9
+        uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           CLEAN: true
           GITHUB_TOKEN: ${{ secrets.DEPLOY_MARIOMENJR }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mariomenjr.com",
   "description": "Personal website for Mario Menjívar",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "scripts": {
     "dev": "sapper dev",
     "build": "sapper build --legacy",


### PR DESCRIPTION
Package: JamesIves/github-pages-deploy-action
Version: 3.5.9 to 3.7.1

Read:
https://github.com/JamesIves/github-pages-deploy-action/issues/500